### PR TITLE
chore: clean up clippy warnings and repair test failures

### DIFF
--- a/client/src/audio/codec.rs
+++ b/client/src/audio/codec.rs
@@ -118,27 +118,35 @@ mod tests {
         let mut encoder = OpusEncoder::new().unwrap();
         let mut decoder = OpusDecoder::new().unwrap();
 
-        // Create a test signal (sine wave)
+        // Create a test signal (sine wave at ~765 Hz, voice band).
         let samples: Vec<f32> = (0..FRAME_SIZE)
             .map(|i| (i as f32 * 0.1).sin() * 0.5)
             .collect();
+        let input_rms: f32 =
+            (samples.iter().map(|x| x * x).sum::<f32>() / samples.len() as f32).sqrt();
 
-        // Encode
+        for _ in 0..3 {
+            let frame = encoder.encode(&samples).unwrap();
+            let _ = decoder.decode(&frame).unwrap();
+        }
+
         let encoded = encoder.encode(&samples).unwrap();
         assert!(!encoded.is_empty());
         assert!(encoded.len() < samples.len() * 4); // Should be compressed
 
-        // Decode
         let decoded = decoder.decode(&encoded).unwrap();
         assert_eq!(decoded.len(), FRAME_SIZE);
 
-        // Lossy codec, so we just check it's roughly similar
-        let max_diff: f32 = samples
-            .iter()
-            .zip(decoded.iter())
-            .map(|(a, b)| (a - b).abs())
-            .fold(0.0, f32::max);
-
-        assert!(max_diff < 0.5, "Max difference too large: {}", max_diff);
+        let output_rms: f32 =
+            (decoded.iter().map(|x| x * x).sum::<f32>() / decoded.len() as f32).sqrt();
+        assert!(
+            output_rms > 0.5 * input_rms,
+            "Output RMS too low: in={input_rms:.3}, out={output_rms:.3}"
+        );
+        assert!(
+            output_rms < 2.0 * input_rms,
+            "Output RMS too high: in={input_rms:.3}, out={output_rms:.3}"
+        );
+        assert!(decoded.iter().all(|s| s.is_finite()));
     }
 }

--- a/client/src/audio/spatial.rs
+++ b/client/src/audio/spatial.rs
@@ -4,8 +4,8 @@
 //! - `Off`    — centered mono; only distance attenuation.
 //! - `Pan2D`  — legacy equal-power horizontal pan from azimuth.
 //! - `Full3D` — ITD (per-ear delay) + front/back one-pole LPF + equal-power
-//!              pan from the full 3D direction, with per-frame parameter
-//!              ramping to avoid zipper noise.
+//!   pan from the full 3D direction, with per-frame parameter ramping to
+//!   avoid zipper noise.
 
 use crate::position::{Position, Transform};
 
@@ -24,17 +24,12 @@ const DELAY_MASK: usize = DELAY_BUF_LEN - 1;
 /// matches the legacy 2D panner so mode A/B loudness stays consistent.
 const CENTER_COMPENSATION: f32 = std::f32::consts::SQRT_2;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum SpatialMode {
     Off,
     Pan2D,
+    #[default]
     Full3D,
-}
-
-impl Default for SpatialMode {
-    fn default() -> Self {
-        SpatialMode::Full3D
-    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/client/src/audio/thread.rs
+++ b/client/src/audio/thread.rs
@@ -305,6 +305,7 @@ impl PlaybackPeer {
 impl PeerRoomStream {
     /// Pull a frame for this stream and render it to stereo. Returns
     /// false when there's nothing buffered yet (caller skips it).
+    #[allow(clippy::too_many_arguments)]
     fn next_spatial_audio(
         &mut self,
         peer_name: &str,

--- a/client/src/network/ws.rs
+++ b/client/src/network/ws.rs
@@ -90,14 +90,14 @@ impl SignalingClient {
                     ClientOutboundMessage::Text(msg) => {
                         let json = serde_json::to_string(&msg).unwrap();
                         log::debug!("Signaling outgoing: {}", json);
-                        if write.send(Message::Text(json.into())).await.is_err() {
+                        if write.send(Message::Text(json)).await.is_err() {
                             log::warn!("Signaling write task: failed to send message");
                             break;
                         }
                     }
                     ClientOutboundMessage::Audio { room_id, data } => {
                         let frame = encode_client_audio_frame(&room_id, &data);
-                        if write.send(Message::Binary(frame.into())).await.is_err() {
+                        if write.send(Message::Binary(frame)).await.is_err() {
                             log::warn!("Signaling write task: failed to send audio");
                             break;
                         }

--- a/client/src/nexus_logger.rs
+++ b/client/src/nexus_logger.rs
@@ -35,7 +35,7 @@ impl log::Log for NexusLogger {
         }
 
         // Send to Nexus logging system. Ignore any errors.
-        let _ = nexus_log(level, target, msg);
+        nexus_log(level, target, msg);
     }
 
     fn flush(&self) {}

--- a/client/src/position/mumble_link.rs
+++ b/client/src/position/mumble_link.rs
@@ -81,7 +81,7 @@ pub fn is_pvp_map_type(map_type: u32) -> bool {
 }
 
 /// Player state snapshot
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct PlayerState {
     pub transform: Transform,
     pub camera_transform: Transform,
@@ -95,21 +95,6 @@ pub struct PlayerState {
     /// a hash of (server_address + map_id + instance) so it is unique per
     /// match but stable across the duration of the same match.
     pub pvp_match_key: Option<String>,
-}
-
-impl Default for PlayerState {
-    fn default() -> Self {
-        Self {
-            transform: Transform::default(),
-            camera_transform: Transform::default(),
-            identity: None,
-            room_key: String::new(),
-            map_id: 0,
-            map_type: 0,
-            ui_tick: 0,
-            pvp_match_key: None,
-        }
-    }
 }
 
 impl PlayerState {
@@ -320,7 +305,7 @@ fn parse_identity(identity: &[u16; 256]) -> Option<PlayerIdentity> {
 /// shard_id so the key is stable across the duration of a single match.
 fn generate_pvp_match_key(context: &MumbleContext) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(&context.server_address);
+    hasher.update(context.server_address);
     hasher.update(context.map_id.to_le_bytes());
     hasher.update(context.instance.to_le_bytes());
     let result = hasher.finalize();
@@ -332,7 +317,7 @@ fn generate_room_key(context: &MumbleContext) -> String {
     let mut hasher = Sha256::new();
 
     // Hash server address (identifies the map server)
-    hasher.update(&context.server_address);
+    hasher.update(context.server_address);
 
     // Hash map ID
     hasher.update(context.map_id.to_le_bytes());

--- a/client/src/ui/settings.rs
+++ b/client/src/ui/settings.rs
@@ -194,11 +194,11 @@ impl SettingsWindow {
 
                     if let Some(_combo) = ui.begin_combo("##input", input_preview) {
                         for (i, device) in self.input_devices.iter().enumerate() {
-                            if Selectable::new(device).build(ui) {
-                                if i != self.selected_input_device {
-                                    self.selected_input_device = i;
-                                    self.pending_input_device = Some(device.clone());
-                                }
+                            if Selectable::new(device).build(ui)
+                                && i != self.selected_input_device
+                            {
+                                self.selected_input_device = i;
+                                self.pending_input_device = Some(device.clone());
                             }
                         }
                     }
@@ -215,11 +215,11 @@ impl SettingsWindow {
 
                     if let Some(_combo) = ui.begin_combo("##output", output_preview) {
                         for (i, device) in self.output_devices.iter().enumerate() {
-                            if Selectable::new(device).build(ui) {
-                                if i != self.selected_output_device {
-                                    self.selected_output_device = i;
-                                    self.pending_output_device = Some(device.clone());
-                                }
+                            if Selectable::new(device).build(ui)
+                                && i != self.selected_output_device
+                            {
+                                self.selected_output_device = i;
+                                self.pending_output_device = Some(device.clone());
                             }
                         }
                     }
@@ -517,7 +517,7 @@ impl SettingsWindow {
                         ui.same_line();
                         if already_joined.contains(&suggestions.room_id) {
                             ui.text_disabled("joined");
-                        } else if ui.small_button(format!("Join##suggest_group")) {
+                        } else if ui.small_button("Join##suggest_group") {
                             self.pending_join_room = Some(suggestions.room_id.clone());
                             self.join_room_error = None;
                         }
@@ -608,10 +608,8 @@ impl SettingsWindow {
                                 if ui.small_button(format!("Unmute##{}", peer.peer_id)) {
                                     self.pending_mutes.push((peer.peer_id.clone(), false));
                                 }
-                            } else {
-                                if ui.small_button(format!("Mute##{}", peer.peer_id)) {
-                                    self.pending_mutes.push((peer.peer_id.clone(), true));
-                                }
+                            } else if ui.small_button(format!("Mute##{}", peer.peer_id)) {
+                                self.pending_mutes.push((peer.peer_id.clone(), true));
                             }
 
                             match peer.account_name.as_deref() {

--- a/client/src/voice/auto_rooms.rs
+++ b/client/src/voice/auto_rooms.rs
@@ -75,10 +75,11 @@ mod tests {
     };
 
     fn in_game_state() -> PlayerState {
-        let mut state = PlayerState::default();
-        state.ui_tick = 1;
-        state.room_key = "abc".to_string();
-        state
+        PlayerState {
+            ui_tick: 1,
+            room_key: "abc".to_string(),
+            ..PlayerState::default()
+        }
     }
 
     fn identity_with(team_color_id: u32, world_id: u32, name: &str) -> PlayerIdentity {
@@ -156,8 +157,10 @@ mod tests {
         let mut state = in_game_state();
         state.identity = Some(identity_with(9, 1001, "Alice"));
         state.map_type = MAP_TYPE_WVW_MIN;
-        let mut settings = VoiceSettings::default();
-        settings.auto_join_wvw_rooms = false;
+        let settings = VoiceSettings {
+            auto_join_wvw_rooms: false,
+            ..VoiceSettings::default()
+        };
         assert_eq!(wvw_team_room_for(&state, &settings), None);
     }
 
@@ -230,8 +233,10 @@ mod tests {
         state.identity = Some(identity_with(5, 1, "Alice"));
         state.map_type = MAP_TYPE_COMPETITIVE;
         state.pvp_match_key = Some("xyz".to_string());
-        let mut settings = VoiceSettings::default();
-        settings.auto_join_pvp_rooms = false;
+        let settings = VoiceSettings {
+            auto_join_pvp_rooms: false,
+            ..VoiceSettings::default()
+        };
         assert_eq!(pvp_team_room_for(&state, &settings), None);
     }
 

--- a/client/src/voice/manager.rs
+++ b/client/src/voice/manager.rs
@@ -21,9 +21,6 @@ use super::peer::VoicePeer;
 use super::persist;
 use super::room_type::RoomType;
 
-// Re-exported so existing callers using `crate::voice::manager::*` paths
-// (e.g. `ui/settings.rs`, `voice/persist/settings.rs`) keep working after
-// the type definitions moved to `super::types`.
 pub use super::types::{
     ApiKeyStatus, GroupSuggestions, NearbyPeer, SpeakingIndicatorSettings, VoiceMode,
     VoiceSettings, VoiceState, DEFAULT_SERVER_URL,
@@ -105,6 +102,11 @@ pub struct VoiceManager {
     // peer marker overlay.
     last_camera_transform: Option<crate::position::Transform>,
     last_fov: Option<f32>,
+
+    // Cached player name from the most recent MumbleLink read. Refreshed
+    // each `update()` tick so the auto-join paths (and tests) don't have
+    // to call into MumbleLink themselves.
+    last_player_name: String,
 
     // Our own GW2 account handle, read from RTAPI when available. Shown in
     // the settings UI so the user can sanity-check the API key they pasted.
@@ -193,6 +195,7 @@ impl VoiceManager {
             last_listener_position: None,
             last_camera_transform: None,
             last_fov: None,
+            last_player_name: "Unknown".to_string(),
             own_account_name: None,
             muted_accounts,
             api_key_status: Arc::new(PlRwLock::new(ApiKeyStatus::Unknown)),
@@ -294,6 +297,7 @@ impl VoiceManager {
             self.last_listener_position = Some(state.camera_transform.position);
             self.last_camera_transform = Some(state.camera_transform);
             self.last_fov = state.identity.as_ref().map(|i| i.fov).filter(|f| *f > 0.0);
+            self.last_player_name = auto_rooms::player_name_from(&state);
             self.send_incoming_audio_command(IncomingAudioCommand::SetListenerTransform(
                 state.camera_transform,
             ));
@@ -460,12 +464,7 @@ impl VoiceManager {
         }
 
         if let Some(new_room) = target {
-            let player_name = self
-                .mumble_link
-                .read()
-                .and_then(|s| s.identity.as_ref().map(|i| i.name.clone()))
-                .filter(|n| !n.trim().is_empty())
-                .unwrap_or_else(|| "Unknown".to_string());
+            let player_name = self.last_player_name.clone();
             if let Err(e) = self.join_room(&new_room, &player_name) {
                 log::warn!("Auto-join of {} failed: {}", new_room, e);
                 return;
@@ -1133,7 +1132,7 @@ impl VoiceManager {
 
     /// Receive audio data for a peer in a specific room. The actual decode
     /// + playback happens on the audio thread (already dispatched by the
-    /// network task); this just refreshes the speaking-indicator timer.
+    ///   network task); this just refreshes the speaking-indicator timer.
     pub fn receive_peer_audio(
         &mut self,
         peer_id: &str,

--- a/client/src/voice/persist/settings.rs
+++ b/client/src/voice/persist/settings.rs
@@ -42,7 +42,10 @@ fn is_wine() -> bool {
     use std::os::raw::{c_char, c_void};
     use std::sync::OnceLock;
 
+    // Match Win32 header naming so call sites read like the C API.
+    #[allow(clippy::upper_case_acronyms)]
     type HMODULE = *mut c_void;
+    #[allow(clippy::upper_case_acronyms)]
     type FARPROC = *const c_void;
 
     extern "system" {
@@ -267,21 +270,23 @@ mod tests {
 
     #[test]
     fn settings_roundtrip_preserves_persistent_fields() {
-        let mut original = VoiceSettings::default();
-        original.mode = VoiceMode::VoiceActivity;
-        original.ptt_key = 0x42;
-        original.min_distance = 250.0;
-        original.max_distance = 7500.0;
-        original.input_volume = 0.8;
-        original.output_volume = 0.6;
-        original.directional_audio_enabled = false;
-        original.spatial_3d_enabled = false;
-        original.show_peer_markers = true;
-        original.server_url = "wss://example.com/ws".to_string();
-        original.gw2_api_key = "secret-key".to_string();
-        // Session-only — should NOT survive the round trip.
-        original.is_muted = true;
-        original.is_deafened = true;
+        let original = VoiceSettings {
+            mode: VoiceMode::VoiceActivity,
+            ptt_key: 0x42,
+            min_distance: 250.0,
+            max_distance: 7500.0,
+            input_volume: 0.8,
+            output_volume: 0.6,
+            directional_audio_enabled: false,
+            spatial_3d_enabled: false,
+            show_peer_markers: true,
+            server_url: "wss://example.com/ws".to_string(),
+            gw2_api_key: "secret-key".to_string(),
+            // Session-only — should NOT survive the round trip.
+            is_muted: true,
+            is_deafened: true,
+            ..VoiceSettings::default()
+        };
 
         let restored = roundtrip_settings(&original);
         assert_eq!(restored.mode, VoiceMode::VoiceActivity);
@@ -304,8 +309,10 @@ mod tests {
 
     #[test]
     fn serialized_settings_never_contain_api_key() {
-        let mut s = VoiceSettings::default();
-        s.gw2_api_key = "DO-NOT-LEAK-THIS-1234".to_string();
+        let s = VoiceSettings {
+            gw2_api_key: "DO-NOT-LEAK-THIS-1234".to_string(),
+            ..VoiceSettings::default()
+        };
         let text = serde_json::to_string_pretty(&s).expect("serialize");
         assert!(
             !text.contains("DO-NOT-LEAK-THIS-1234"),

--- a/client/src/voice/types.rs
+++ b/client/src/voice/types.rs
@@ -48,6 +48,7 @@ pub struct VoiceSettings {
     pub input_volume: f32,
     pub output_volume: f32,
     /// Session-only
+    #[serde(skip)]
     pub is_muted: bool,
     /// Session-only
     #[serde(skip)]

--- a/server/src/squad.rs
+++ b/server/src/squad.rs
@@ -68,7 +68,7 @@ impl SquadRegistry {
             if overlap < MIN_OVERLAP {
                 continue;
             }
-            if best.as_ref().map_or(true, |(_, o)| overlap > *o) {
+            if best.as_ref().is_none_or(|(_, o)| overlap > *o) {
                 best = Some((cluster.id.clone(), overlap));
             }
         }


### PR DESCRIPTION
Clears clippy warnings and fixes the client tests that were failing on main.